### PR TITLE
Update control_coupling-pid.cpp

### DIFF
--- a/src/control_coupling-pid.cpp
+++ b/src/control_coupling-pid.cpp
@@ -40,6 +40,6 @@ float CouplingPID::control_y(const float input, Data data) {
     return output;
 }
 
-bool CouplingPID::Release() {
-    return false;
+void CouplingPID::Release() {
+    false;
 }


### PR DESCRIPTION
修复：错误E0147，声明与 "void CouplingPID::Release()" (已声明 所在行数:39，所属文件:"SF_TRT_62-master\src\control_coupling-pid.h") 不兼容